### PR TITLE
Fix broken link on the getting started page

### DIFF
--- a/docs/get-started/tutorial/index.rst
+++ b/docs/get-started/tutorial/index.rst
@@ -11,7 +11,7 @@ Getting Started
 ----------------------
 
 We use `git <http://git-scm.com>`_ to manage and distribute source code.  Download InterMine software from :doc:`/git/index`
-inter
+
 Creating a new Mine
 ----------------------
 


### PR DESCRIPTION
Not sure if I missed something, but the formatting on the getting started page was broken! This seems to fix it
