### PR TITLE
fixed typos in get-started tutorial files

### DIFF
--- a/docs/get-started/tutorial/index.rst
+++ b/docs/get-started/tutorial/index.rst
@@ -392,7 +392,7 @@ Object relational mapping
  
 InterMine works with objects, objects are loaded into the production system and queries return lists of objects.  These objects are persisted to a relational database. Internal InterMine code (the ObjectStore) handles the storage and retrieval of objects from the database automatically. By using an object model InterMine queries benefit from inheritance, for example the `Gene` and `Exon` classes are both subclasses of `SequenceFeature`.  When querying for SequenceFeatures (representing any genome feature) both Genes and Exons will be returned automatically.  
 
-We can see how see how inheritance is represented in the database:
+We can see how inheritance is represented in the database:
 
 * One table is created for each class in the data model.
 * Where one class inherits from another, entries are written to both tables.  For example:
@@ -433,7 +433,7 @@ We will load genome annotation data for *P. falciparum* from PlasmoDB
 Data integration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Note that genes from the gff3 file will have the same `primaryIdentifier` as those already loaded from UniProt.  These will  merge in the database such that there is only one copy of each gene with information from both data sources. We will load the genome data then look at how data integration in InterMine works.
+Note that genes from the GFF3 file will have the same `primaryIdentifier` as those already loaded from UniProt.  These will  merge in the database such that there is only one copy of each gene with information from both data sources. We will load the genome data then look at how data integration in InterMine works.
 
 First, look at the information currently loaded for gene `PFL1385c` from UniProt:
 
@@ -660,7 +660,7 @@ The keys used by each source are set in the source's `resources` directory.
 * `uniprot-malaria <https://github.com/intermine/intermine/blob/master/bio/sources/uniprot/src/main/resources/uniprot_keys.properties>`_
 * `malaria-gff <https://github.com/intermine/intermine/blob/master/bio/sources/example-sources/malaria-gff/src/main/resources/malaria-gff_keys.properties>`_
 
-The key on `Gene.primaryIdentifier` is defined in both sources, that means that the same final result would have been achieved regardless of the order in the two sources were loaded.  
+The key on `Gene.primaryIdentifier` is defined in both sources, that means that the same final result would have been achieved regardless of the order in which the two sources were loaded.  
 
 These `_keys.properties` files define keys in the format:
 
@@ -675,7 +675,7 @@ The `name_of_key` can be any string but you must use different names if defining
   Gene.key_primaryidentifier = primaryIdentifier
   Gene.key_secondaryidentifier = secondaryIdentifier
 
-It is better to use common names for identical keys between sources as this will help avoid duplicating database indexes. Each key should list one or more fields that can be a combination of `attributes` of the class specified or `references` to other classes, in this cases there should usually be a key defined for the referenced class as well.
+It is better to use common names for identical keys between sources as this will help avoid duplicating database indexes. Each key should list one or more fields that can be a combination of `attributes` of the class specified or `references` to other classes, in this case there should usually be a key defined for the referenced class as well.
 
 The `tracker` table 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -752,7 +752,7 @@ Now run the `update-publications` source to fill in the details:
 
   ~/git/biotestmine $ ./gradlew integrate -Psource=update-publications --stacktrace
 
-As there are often large numbers of publications they are retrieved in batches from the web service.
+As there are often large numbers of publications, they are retrieved in batches from the web service.
 
 Now details will have been added to the `publication` table:
 
@@ -760,7 +760,7 @@ Now details will have been added to the `publication` table:
 
   biotestmine#  select * from publication where title is not null limit 5;
 
-As this source depends on publication data previously loaded it should be one of the last sources run and should appear at the end of `<sources>` in `project.xml`.
+As this source depends on publication data previously loaded, it should be one of the last sources run and should appear at the end of `<sources>` in `project.xml`.
 
 Post Processing
 --------------------------------------------
@@ -860,11 +860,11 @@ To create a Intermine collection for autocomplete process, run this command insi
     # Initaliases the autocomplete index
     solr-7.2.1 $ ./bin/solr create -c biotestmine-autocomplete
 
-These are empty search indexes. These will be populated by the `create-search-index` & `create-autocomplete-index` postprocesses. 
+These are empty search indexes that will be populated by the `create-search-index` & `create-autocomplete-index` postprocesses. 
 
 See :doc:`/system-requirements/software/solr` for details.
 
-Execute the `create-search-index` and `create-autocomplete-index` postprocesses by running this command:
+Execute the `create-search-index` and `create-autocomplete-index` postprocesses by running these commands:
 
 ::
 
@@ -919,7 +919,7 @@ In the `~/.intermine` directory, update the webapp properties in your biotestmin
 UserProfile
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The userprofile database stores all user-related information such as username and password, tags, queries, lists and templates.
+The userprofile database stores all user-related information such as username and password, tags, queries, lists and templates. To build the userprofile database:
 
 1. Configure 
 
@@ -957,7 +957,7 @@ Deploying the webapp
 
 Before deploying the biotestmine webapp, you need to configure tomcat. See :doc:`/system-requirements/software/tomcat` for configuration details.
 
-Run the following command to release your webapp: 
+Run the following command to deploy your webapp: 
 
 ::
 

--- a/docs/get-started/tutorial/test-data.rst
+++ b/docs/get-started/tutorial/test-data.rst
@@ -11,7 +11,7 @@ All data required to build an InterMine is included in `biotestmine/data/malaria
 	cd DATA_DIR
 	tar -zxvf malaria-data.tar.gz
 
-Edit the project.xml file so that all occurances of ''DATA_DIR'' point to the your local data directory location. 
+Edit the project.xml file so that all occurrences of ''DATA_DIR'' point to the your local data directory location. 
 
 Data sources
 -----------------

--- a/docs/get-started/tutorial/webapp.rst
+++ b/docs/get-started/tutorial/webapp.rst
@@ -40,7 +40,7 @@ Header
 Logo
 ^^^^^
 
-First, let's update the logo of your site. The logo should be 45x43 and named `logo.png`, for example:
+First, let's update the logo of your site. The logo should be 45x43pixels and named `logo.png`, for example:
 
 .. figure:: ../../imgs/logo.png
    :align:   center
@@ -61,7 +61,7 @@ First, let's update the logo of your site. The logo should be 45x43 and named `l
 
    Updated logo
 
-You should see your new logo in the top left corner of your webapp. If you don't, try clearing your browser's cache.
+You should see your new logo at the top left corner of your webapp. If you don't, try clearing your browser's cache.
 
 clean
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -86,7 +86,7 @@ Next to the name of your mine in the header is the release version and subtitle 
 
    Title, release version and subtitle
 
-These values are set in :doc:`/webapp/properties/intermine-properties` file. This is the same properties file you updated in the previous tutorial. The subtitle and release versions are populated by the properties `project.subTitle` and `project.releaseVersion`, respectively. Update these properties to a different value and redeploy your webapp using the commands given above. Once you have successfully released your webapp, you should see your new subtitle.
+These values are set in :doc:`/webapp/properties/intermine-properties` file. This is the same properties file you updated in the previous tutorial. The subtitle and release versions are populated by the properties `project.subTitle` and `project.releaseVersion`, respectively. Update these properties to a different value and redeploy your webapp using the commands given below. Once you have successfully released your webapp, you should see your new subtitle.
 
 1. Open the properties file in your favourite text editor.
 
@@ -142,7 +142,7 @@ Ask us!
 	1. Log in as the superuser for your mine. (See :doc:`/webapp/admin/index` for details on how to do this.)
 	2. Change the last part of the URL in your browser to be `showProperties.do`, e.g. http://localhost:8080/biotestmine/showProperties.do
 
-	This lists of all properties that are used in your webapp. You can update the values for each property and instantly see how the webapp is changed, without worrying about breaking anything. (The changes only last for that session, to permanently change a value you'll need to update the appropriate config file.)
+	This lists all properties that are used in your webapp. You can update the values for each property and instantly see how the webapp is changed, without worrying about breaking anything. (The changes only last for that session, to permanently change a value you'll need to update the appropriate config file.)
 
 Keyword Search 
 ~~~~~~~~~~~~~~~~~~~~~
@@ -192,7 +192,7 @@ The :doc:`model.properties </webapp/properties/model-properties>` is the third c
 .. topic:: InterMine properties files
 
 	:doc:`~/.intermine/biotestmine.properties </webapp/properties/intermine-properties>`
-  		database and webapp names and locations. includes passwords and shouldn't be in source control.
+  		database and webapp names and locations, includes passwords and shouldn't be in source control.
 
 	:doc:`web.properties </webapp/properties/web-properties>`
   		webapp behaviour, e.g. link outs, tabs on home page
@@ -208,7 +208,7 @@ See :doc:`/webapp/layout/index` for more details on how to update the header, fo
 Home page
 ----------------------
 
-Most everything on the home page is customisable. You can edit the text and set which RSS news feed to use. If you want something very different, you can create and use your own home page.
+Almost everything on the home page is customisable. You can edit the text and set which RSS news feed to use. If you want something very different, you can create and use your own home page.
 
 Boxes
 ~~~~~~~


### PR DESCRIPTION
Fixed typos in index.rst, test-data.rst and webapp.rst in '/get-started/tutorial'

