### PR TITLE
Typo fixes

### DIFF
--- a/docs/get-started/intermine-tests.rst
+++ b/docs/get-started/intermine-tests.rst
@@ -4,7 +4,7 @@ InterMine Tests
 Continuous Integration
 -------------------------
 
-We run all our tests on every commit using the Continous Integration service
+We run all our tests on every commit using the Continuous Integration service
 `Travis <https://travis-ci.org/intermine/intermine>`_. You can do the same for your fork:
 
   * Log in to Travis-CI with your GitHub account.
@@ -20,7 +20,7 @@ After getting the source code for InterMine and ensuring you have all of the
 required prerequisites, the next step is to try the tests to confirm that
 everything runs well in your environment.
 
-We also recommend looking at the files that run our continous integration tests
+We also recommend looking at the files that run our continuous integration tests
 for examples of how this can be automated:
 
   * `config/travis/init.sh`

--- a/docs/get-started/testmine.rst
+++ b/docs/get-started/testmine.rst
@@ -1,7 +1,7 @@
 Testmine
 ==========
 
-This is an InterMine used for testing new features, and for continuous integration tests on Travis. Its tables include: Employee, Company, Department. The mine does not contain biological data. 
+This is an InterMine used for testing new features, and for continuous integration tests on Travis. Its tables include: Employee, Company and Department. The mine does not contain biological data. 
 
 To start a testmine, run the `setup <https://github.com/intermine/intermine/blob/master/testmine/setup.sh>`_ script:
 

--- a/docs/get-started/tutorial/index.rst
+++ b/docs/get-started/tutorial/index.rst
@@ -392,7 +392,7 @@ Object relational mapping
  
 InterMine works with objects, objects are loaded into the production system and queries return lists of objects.  These objects are persisted to a relational database. Internal InterMine code (the ObjectStore) handles the storage and retrieval of objects from the database automatically. By using an object model InterMine queries benefit from inheritance, for example the `Gene` and `Exon` classes are both subclasses of `SequenceFeature`.  When querying for SequenceFeatures (representing any genome feature) both Genes and Exons will be returned automatically.  
 
-We can see how see how inheritance is represented in the database:
+We can see how inheritance is represented in the database:
 
 * One table is created for each class in the data model.
 * Where one class inherits from another, entries are written to both tables.  For example:
@@ -433,7 +433,7 @@ We will load genome annotation data for *P. falciparum* from PlasmoDB
 Data integration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Note that genes from the gff3 file will have the same `primaryIdentifier` as those already loaded from UniProt.  These will  merge in the database such that there is only one copy of each gene with information from both data sources. We will load the genome data then look at how data integration in InterMine works.
+Note that genes from the GFF3 file will have the same `primaryIdentifier` as those already loaded from UniProt.  These will  merge in the database such that there is only one copy of each gene with information from both data sources. We will load the genome data then look at how data integration in InterMine works.
 
 First, look at the information currently loaded for gene `PFL1385c` from UniProt:
 
@@ -660,7 +660,7 @@ The keys used by each source are set in the source's `resources` directory.
 * `uniprot-malaria <https://github.com/intermine/intermine/blob/master/bio/sources/uniprot/src/main/resources/uniprot_keys.properties>`_
 * `malaria-gff <https://github.com/intermine/intermine/blob/master/bio/sources/example-sources/malaria-gff/src/main/resources/malaria-gff_keys.properties>`_
 
-The key on `Gene.primaryIdentifier` is defined in both sources, that means that the same final result would have been achieved regardless of the order in the two sources were loaded.  
+The key on `Gene.primaryIdentifier` is defined in both sources, that means that the same final result would have been achieved regardless of the order in which the two sources were loaded.  
 
 These `_keys.properties` files define keys in the format:
 
@@ -675,7 +675,7 @@ The `name_of_key` can be any string but you must use different names if defining
   Gene.key_primaryidentifier = primaryIdentifier
   Gene.key_secondaryidentifier = secondaryIdentifier
 
-It is better to use common names for identical keys between sources as this will help avoid duplicating database indexes. Each key should list one or more fields that can be a combination of `attributes` of the class specified or `references` to other classes, in this cases there should usually be a key defined for the referenced class as well.
+It is better to use common names for identical keys between sources as this will help avoid duplicating database indexes. Each key should list one or more fields that can be a combination of `attributes` of the class specified or `references` to other classes, in this case there should usually be a key defined for the referenced class as well.
 
 The `tracker` table 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -752,7 +752,7 @@ Now run the `update-publications` source to fill in the details:
 
   ~/git/biotestmine $ ./gradlew integrate -Psource=update-publications --stacktrace
 
-As there are often large numbers of publications they are retrieved in batches from the web service.
+As there are often large numbers of publications, they are retrieved in batches from the web service.
 
 Now details will have been added to the `publication` table:
 
@@ -760,7 +760,7 @@ Now details will have been added to the `publication` table:
 
   biotestmine#  select * from publication where title is not null limit 5;
 
-As this source depends on publication data previously loaded it should be one of the last sources run and should appear at the end of `<sources>` in `project.xml`.
+As this source depends on publication data previously loaded, it should be one of the last sources run and should appear at the end of `<sources>` in `project.xml`.
 
 Post Processing
 --------------------------------------------
@@ -860,11 +860,11 @@ To create a Intermine collection for autocomplete process, run this command insi
     # Initaliases the autocomplete index
     solr-7.2.1 $ ./bin/solr create -c biotestmine-autocomplete
 
-These are empty search indexes. These will be populated by the `create-search-index` & `create-autocomplete-index` postprocesses. 
+These are empty search indexes that will be populated by the `create-search-index` & `create-autocomplete-index` postprocesses. 
 
 See :doc:`/system-requirements/software/solr` for details.
 
-Execute the `create-search-index` and `create-autocomplete-index` postprocesses by running this command:
+Execute the `create-search-index` and `create-autocomplete-index` postprocesses by running these commands:
 
 ::
 
@@ -919,7 +919,7 @@ In the `~/.intermine` directory, update the webapp properties in your biotestmin
 UserProfile
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The userprofile database stores all user-related information such as username and password, tags, queries, lists and templates.
+The userprofile database stores all user-related information such as username and password, tags, queries, lists and templates. To build the userprofile database:
 
 1. Configure 
 
@@ -957,7 +957,7 @@ Deploying the webapp
 
 Before deploying the biotestmine webapp, you need to configure tomcat. See :doc:`/system-requirements/software/tomcat` for configuration details.
 
-Run the following command to release your webapp: 
+Run the following command to deploy your webapp: 
 
 ::
 

--- a/docs/get-started/tutorial/test-data.rst
+++ b/docs/get-started/tutorial/test-data.rst
@@ -11,7 +11,7 @@ All data required to build an InterMine is included in `biotestmine/data/malaria
 	cd DATA_DIR
 	tar -zxvf malaria-data.tar.gz
 
-Edit the project.xml file so that all occurances of ''DATA_DIR'' point to the your local data directory location. 
+Edit the project.xml file so that all occurrences of ''DATA_DIR'' point to the your local data directory location. 
 
 Data sources
 -----------------

--- a/docs/get-started/tutorial/webapp.rst
+++ b/docs/get-started/tutorial/webapp.rst
@@ -40,7 +40,7 @@ Header
 Logo
 ^^^^^
 
-First, let's update the logo of your site. The logo should be 45x43 and named `logo.png`, for example:
+First, let's update the logo of your site. The logo should be 45x43pixels and named `logo.png`, for example:
 
 .. figure:: ../../imgs/logo.png
    :align:   center
@@ -61,7 +61,7 @@ First, let's update the logo of your site. The logo should be 45x43 and named `l
 
    Updated logo
 
-You should see your new logo in the top left corner of your webapp. If you don't, try clearing your browser's cache.
+You should see your new logo at the top left corner of your webapp. If you don't, try clearing your browser's cache.
 
 clean
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -86,7 +86,7 @@ Next to the name of your mine in the header is the release version and subtitle 
 
    Title, release version and subtitle
 
-These values are set in :doc:`/webapp/properties/intermine-properties` file. This is the same properties file you updated in the previous tutorial. The subtitle and release versions are populated by the properties `project.subTitle` and `project.releaseVersion`, respectively. Update these properties to a different value and redeploy your webapp using the commands given above. Once you have successfully released your webapp, you should see your new subtitle.
+These values are set in :doc:`/webapp/properties/intermine-properties` file. This is the same properties file you updated in the previous tutorial. The subtitle and release versions are populated by the properties `project.subTitle` and `project.releaseVersion`, respectively. Update these properties to a different value and redeploy your webapp using the commands given below. Once you have successfully released your webapp, you should see your new subtitle.
 
 1. Open the properties file in your favourite text editor.
 
@@ -142,7 +142,7 @@ Ask us!
 	1. Log in as the superuser for your mine. (See :doc:`/webapp/admin/index` for details on how to do this.)
 	2. Change the last part of the URL in your browser to be `showProperties.do`, e.g. http://localhost:8080/biotestmine/showProperties.do
 
-	This lists of all properties that are used in your webapp. You can update the values for each property and instantly see how the webapp is changed, without worrying about breaking anything. (The changes only last for that session, to permanently change a value you'll need to update the appropriate config file.)
+	This lists all properties that are used in your webapp. You can update the values for each property and instantly see how the webapp is changed, without worrying about breaking anything. (The changes only last for that session, to permanently change a value you'll need to update the appropriate config file.)
 
 Keyword Search 
 ~~~~~~~~~~~~~~~~~~~~~
@@ -192,7 +192,7 @@ The :doc:`model.properties </webapp/properties/model-properties>` is the third c
 .. topic:: InterMine properties files
 
 	:doc:`~/.intermine/biotestmine.properties </webapp/properties/intermine-properties>`
-  		database and webapp names and locations. includes passwords and shouldn't be in source control.
+  		database and webapp names and locations, includes passwords and shouldn't be in source control.
 
 	:doc:`web.properties </webapp/properties/web-properties>`
   		webapp behaviour, e.g. link outs, tabs on home page
@@ -208,7 +208,7 @@ See :doc:`/webapp/layout/index` for more details on how to update the header, fo
 Home page
 ----------------------
 
-Most everything on the home page is customisable. You can edit the text and set which RSS news feed to use. If you want something very different, you can create and use your own home page.
+Almost everything on the home page is customisable. You can edit the text and set which RSS news feed to use. If you want something very different, you can create and use your own home page.
 
 Boxes
 ~~~~~~~

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 InterMine documentation
 ================================
 
-`InterMine <http://www.intermine.org/>`_ is an open source data warehouse build specifically for the integration and analysis of complex biological data.
+`InterMine <http://www.intermine.org/>`_ is an open source data warehouse built specifically for the integration and analysis of complex biological data.
 
 Developed by the `Micklem lab <http://www.micklemlab.org/>`_ at the `University of Cambridge <https://www.gen.cam.ac.uk/>`_, InterMine enables the creation of biological databases accessed by sophisticated web query tools. Parsers are provided for integrating data from many common biological data sources and formats, and there is a framework for adding your own data. InterMine includes an attractive, user-friendly web interface that works 'out of the box' and can be easily customised for your specific needs, as well as a powerful, scriptable web-service API to allow programmatic access to your data.
 

--- a/docs/intermine/amazon.rst
+++ b/docs/intermine/amazon.rst
@@ -1,7 +1,7 @@
 How to set up your InterMine environment on the Amazon Cloud
 ================================================================
 
-Where you should learn how to start your own MalariaMine web application on the Amazon Cloud. You could also use your InterMine Amazon instance to try building MalariaMine yourself or to build your own mine there.
+This is where you should learn how to start your own MalariaMine web application on the Amazon Cloud. You could also use your InterMine Amazon instance to try building MalariaMine yourself or to build your own mine there.
 
 Pre-requisites
 ----------------------
@@ -22,14 +22,14 @@ The image contains a ready deployed MalariaMine.
 
 1. sign in at http://aws.amazon.com
 2. go to the EC2 management console
-   AWS console https://console.aws.amazon.com/console/home --> EC2 console
-3. if you don't have one, set up a security group which allows access at least to port
+  AWS console --> https://console.aws.amazon.com/console/home --> EC2 console
+3. if you don't have one, set up a security group which allows access to at least port
 
   * 22 (SSH)
   * 80 (HTTP)
   * 8080 (TOMCAT)
 
-  you could set up also a few spare ones (20, 21, 8009).
+  you could also set up a few spare ones (20, 21, 8009).
 
 .. note::
 
@@ -94,7 +94,7 @@ In ``/webapp`` you'll find tomcat6. You can start the webapp using this command:
 
  $ ./start.sh
 
-Your BioTestMine web application will be then available on
+Your BioTestMine web application will then be available on
 
   http://the_instance_public_DNS:8080/malariamine
 

--- a/docs/intermine/intermine-versions.rst
+++ b/docs/intermine/intermine-versions.rst
@@ -12,7 +12,7 @@ MINOR  functionality added in a backwards-compatible manner
 PATCH  backwards-compatible bug fixes
 ====== ====================================================
 
-InterMine releases a new major version containing new features about once a year. Each major version receives bug fixes and, if need be, security fixes that are released at least once every three months in what we call a "minor release." For more information on the minor release schedule, you can view the minor release :doc:`</intermine/roadmap>`.
+InterMine releases a new major version containing new features about once a year. Each major version receives bug fixes and, if need be, security fixes that are released at least once every three months in what we call a "minor release." For more information on the minor release schedule, you can view the minor release :doc:`roadmap </intermine/roadmap>`.
 
 If the release team determines that a critical bug or security fix is too important to wait until the regularly scheduled minor release, it may make a release available outside of the minor release schedule.
 

--- a/docs/intermine/intermine-versions.rst
+++ b/docs/intermine/intermine-versions.rst
@@ -25,6 +25,6 @@ Major versions often change the data model or the InterMine API. These changes a
 
 Upgrading to a minor release does not normally require a database rebuild; you can stop your webapp, update your InterMine version number, and redeploy your webapp. For some releases, manual changes may be required to complete the upgrade, so always read the release notes before upgrading.
 
-While upgrading will always contain some level of risk, InterMine minor releases fix only frequently-encountered bugs, security issues, and blocking problems to reduce the risk associated with upgrading. For minor releases, the **community considers not upgrading to be riskier than upgrading**. 
+While upgrading will always contain some level of risk, InterMine minor releases fix only frequently-encountered bugs, security issues and blocking problems to reduce the risk associated with upgrading. For minor releases, the **community considers not upgrading to be riskier than upgrading**. 
 
 .. index:: version, semantic versioning, JAR version

--- a/docs/intermine/upgrade.rst
+++ b/docs/intermine/upgrade.rst
@@ -64,7 +64,7 @@ InterMine 4.1.0
 
 This is a non-disruptive release.
 
-Galaxy integration has been improved; you should remove the galaxy related properties from the web.properties file to benefit of it.
+Galaxy integration has been improved; you should remove the galaxy related properties from the web.properties file to benefit from it.
 
 Integration with ELIXIR AAI has been included.
 

--- a/docs/intermine/upgrade.rst
+++ b/docs/intermine/upgrade.rst
@@ -286,7 +286,7 @@ Note the command is `./gradlew` instead of `gradle`. Use the provided Gradle wra
 
 You will have to `install` your sources every time you update the source code to update the JAR being used by the build.
 
-Previously the data model was merged from all data sources' additions XML file. This is no longer true. Since each source is in its own JAR now, the data model is self-contained. Therefore if you reference a class in your data parser, it must be present in the additions file. Alternatively, you can specify a single data model file that will be merged into each source:
+Previously, the data model was merged from all data sources' additions XML file. This is no longer true. Since each source is in its own JAR now, the data model is self-contained. Therefore if you reference a class in your data parser, it must be present in the additions file. Alternatively, you can specify a single data model file that will be merged into each source:
 
 .. code-block:: sh
 
@@ -340,7 +340,7 @@ Data Model
 
 See the `Model Changes <https://intermineorg.wordpress.com/2017/09/08/intermine-2-0-proposed-model-changes-iii/>`_ blog post for details.
 
-You have may to update your data sources and queries to match the new data model.
+You may have to update your data sources and queries to match the new data model.
 
 Dependencies
 --------------------------
@@ -453,7 +453,7 @@ We've added a new fancy connection pool, you should see a performance improvemen
 Postgres config file 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The number of database connections required will depend on your usage. 100 connections is the default and should be okay for production webapps. However each webapp reserves 20 connections so on your dev machines it may be wise to raise the maximum quite a bit.
+The number of database connections required will depend on your usage. 100 connections is the default and should be okay for production webapps. However, each webapp reserves 20 connections. So, on your dev machines it may be wise to raise the maximum quite a bit.
 
 .. topic:: postgresql.conf
 
@@ -520,7 +520,7 @@ See :doc:`/system-requirements/software/postgres/hikari` for details.
 InterMine-model Refactor
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The metadata package has moved from to `InterMine-model <https://github.com/intermine/intermine/tree/beta/intermine/model/main/src/org/intermine>`_. If you have custom data sources that use InterMine Utils, you may have to update your code to reflect the new location. Your IDE should be able to do this for you. 
+The metadata package has moved to `InterMine-model <https://github.com/intermine/intermine/tree/beta/intermine/model/main/src/org/intermine>`_. If you have custom data sources that use InterMine Utils, you may have to update your code to reflect the new location. Your IDE should be able to do this for you. 
 
 Tomcat
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -548,7 +548,7 @@ Upgrade to InterMine 1.3
   * DataSet now has a publication reference
   * AnnotationExtension has been moved from GOAnnotation to GOEvidence.
 
-Also, we have changed our GO parser a bit. Each line in a gene annotation file now corresponds with an Evidence object. In prior releases, each Evidence object was unique, e.g. only a single evidence code per gene / GO term pair.
+Also, we have changed our GO parser a bit. Each line in a gene annotation file now corresponds with an Evidence object. In prior releases, each Evidence object was unique e.g. only a single evidence code per gene / GO term pair.
 
 Upgrade to InterMine 1.2.1
 ---------------------------------


### PR DESCRIPTION
Fixed typos, restructured some sentences in 'docs/index.rst' and files under 'docs/intermine' and 'docs/get-started'.